### PR TITLE
Add dry run support to apply and delete

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run E2E tests
         env:
           GH_TEMPLATER_TOKEN: ${{ secrets.GH_TEMPLATER_TOKEN }}
-        run: go test ./internal/e2e -run TestApplyTemplateE2E -count=1
+        run: go test ./internal/e2e -count=1
 
       - name: Cleanup E2E artifacts
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,4 +59,8 @@ jobs:
           export GH_TOKEN="${GH_TEMPLATER_TOKEN}"
           export GITHUB_TOKEN="${GH_TEMPLATER_TOKEN}"
           gh extension install . >/dev/null 2>&1 || gh extension upgrade gh-templater >/dev/null 2>&1 || true
-          gh templater delete --org spacetj --project "${GH_TEMPLATER_E2E_PROJECT}" --issues-repo spacetj/gh-templater --template templates/e2e-smoke.yaml || true
+          gh templater delete \
+            --org spacetj \
+            --project "${GH_TEMPLATER_E2E_PROJECT}" \
+            --issues-repo spacetj/gh-templater \
+            --template templates/e2e-smoke.yaml || true

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ gh templater apply \
   --sections labels,issues
 ```
 
+Need to sanity-check a template before mutating anything? Append `--dry-run` to `gh templater apply` or `gh templater delete` to preview the entire plan. The CLI prints each step (ensuring labels, creating milestones and issues, setting project fields, deleting resources, etc.) without calling the GitHub API so you can validate the workflow before running it for real.
+
 The command will:
 - 🚧 Create or update a GitHub Project (Projects v2) under the org you specify (when `project` is selected).
 - 🏷️ Ensure repo labels match the template (when `labels` is selected).

--- a/cmd/gh-templater/main.go
+++ b/cmd/gh-templater/main.go
@@ -35,6 +35,7 @@ func applyCmd(args []string) {
 	issuesRepo := fs.String("issues-repo", "", "owner/repo that will receive milestones and issues")
 	templatePath := fs.String("template", "", "Path to the YAML template to apply")
 	sectionsFlag := fs.String("sections", "all", "Comma-separated sections to apply (project,labels,milestones,issues or 'all')")
+	dryRun := fs.Bool("dry-run", false, "Preview the actions without calling the GitHub API")
 
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -54,7 +55,7 @@ func applyCmd(args []string) {
 	}
 
 	client := github.NewCLIClient(runner.ExecRunner{})
-	opts := apply.Options{Org: *org, ProjectName: *project, IssuesRepo: *issuesRepo, Template: *templatePath, Sections: sections}
+	opts := apply.Options{Org: *org, ProjectName: *project, IssuesRepo: *issuesRepo, Template: *templatePath, Sections: sections, DryRun: *dryRun}
 	if err := apply.Apply(opts, client); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -68,6 +69,7 @@ func deleteCmd(args []string) {
 	issuesRepo := fs.String("issues-repo", "", "owner/repo containing issues and milestones to cleanup")
 	templatePath := fs.String("template", "", "Path to the YAML template describing issues and milestones to delete")
 	sectionsFlag := fs.String("sections", "all", "Comma-separated sections to delete (project,labels,milestones,issues or 'all')")
+	dryRun := fs.Bool("dry-run", false, "Preview the delete actions without calling the GitHub API")
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -89,6 +91,7 @@ func deleteCmd(args []string) {
 		IssuesRepo:  *issuesRepo,
 		Template:    *templatePath,
 		Sections:    sections,
+		DryRun:      *dryRun,
 	}
 	if err := apply.Delete(opts, client); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"fmt"
+	"io"
 	"strconv"
 	"strings"
 
@@ -61,11 +62,13 @@ func (s Sections) anyEnabled() bool {
 
 // Options describe inputs provided via CLI flags.
 type Options struct {
-	Org         string
-	ProjectName string
-	IssuesRepo  string
-	Template    string
-	Sections    Sections
+	Org          string
+	ProjectName  string
+	IssuesRepo   string
+	Template     string
+	Sections     Sections
+	DryRun       bool
+	DryRunWriter io.Writer
 }
 
 // Apply executes the project bootstrapping flow.
@@ -74,6 +77,7 @@ func Apply(opts Options, client github.Client) error {
 	if !sections.anyEnabled() {
 		sections = DefaultSections()
 	}
+	runner := newStepRunner(opts.DryRun, opts.DryRunWriter)
 
 	tpl, err := template.Load(opts.Template)
 	if err != nil {
@@ -87,7 +91,11 @@ func Apply(opts Options, client github.Client) error {
 
 	if sections.Labels {
 		for _, label := range tpl.Labels {
-			if err := client.EnsureLabel(opts.IssuesRepo, label.Name, label.Color, label.Description); err != nil {
+			lbl := label
+			description := fmt.Sprintf("Ensure label %q in %s", lbl.Name, opts.IssuesRepo)
+			if err := runner.Run(description, func() error {
+				return client.EnsureLabel(opts.IssuesRepo, lbl.Name, lbl.Color, lbl.Description)
+			}); err != nil {
 				return err
 			}
 		}
@@ -96,19 +104,40 @@ func Apply(opts Options, client github.Client) error {
 	var project github.ProjectInfo
 	var projectFields map[string]github.ProjectField
 	if sections.Project {
-		project, err = client.CreateProject(opts.Org, opts.ProjectName)
-		if err != nil {
-			return fmt.Errorf("create project: %w", err)
+		description := fmt.Sprintf("Create project %q under %s", opts.ProjectName, opts.Org)
+		if err := runner.Run(description, func() error {
+			var err error
+			project, err = client.CreateProject(opts.Org, opts.ProjectName)
+			if err != nil {
+				return fmt.Errorf("create project: %w", err)
+			}
+			return nil
+		}); err != nil {
+			return err
 		}
 
-		if err := client.UpdateProjectReadme(project.ID, projectConfig.Readme); err != nil {
+		if err := runner.Run(fmt.Sprintf("Update README for project %q", opts.ProjectName), func() error {
+			if err := client.UpdateProjectReadme(project.ID, projectConfig.Readme); err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
 			return err
 		}
 
 		fieldTemplates := convertFieldTemplates(projectConfig.Fields)
-		projectFields, err = client.EnsureProjectFields(project.ID, fieldTemplates)
-		if err != nil {
-			return fmt.Errorf("ensure project fields: %w", err)
+		if err := runner.Run(fmt.Sprintf("Ensure project fields for %q", opts.ProjectName), func() error {
+			var err error
+			projectFields, err = client.EnsureProjectFields(project.ID, fieldTemplates)
+			if err != nil {
+				return fmt.Errorf("ensure project fields: %w", err)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+		if opts.DryRun {
+			projectFields = simulateProjectFieldMetadata(fieldTemplates)
 		}
 	}
 
@@ -118,7 +147,11 @@ func Apply(opts Options, client github.Client) error {
 		if !sections.Milestones {
 			continue
 		}
-		if err := client.CreateMilestone(opts.IssuesRepo, m.Title, m.Description, m.DueOn); err != nil {
+		milestone := m
+		description := fmt.Sprintf("Create milestone %q in %s", milestone.Title, opts.IssuesRepo)
+		if err := runner.Run(description, func() error {
+			return client.CreateMilestone(opts.IssuesRepo, milestone.Title, milestone.Description, milestone.DueOn)
+		}); err != nil {
 			return err
 		}
 	}
@@ -140,18 +173,33 @@ func Apply(opts Options, client github.Client) error {
 				Assignees: issue.Assignees,
 			}
 
-			url, err := client.CreateIssue(opts.IssuesRepo, issueInput)
-			if err != nil {
+			var issueURL string
+			description := fmt.Sprintf("Create issue %q in %s", issue.Title, opts.IssuesRepo)
+			if err := runner.Run(description, func() error {
+				var err error
+				issueURL, err = client.CreateIssue(opts.IssuesRepo, issueInput)
+				if err != nil {
+					return err
+				}
+				return nil
+			}); err != nil {
 				return err
 			}
 
 			if sections.Project {
-				itemID, err := client.AddItemToProject(opts.Org, project.Number, url)
-				if err != nil {
+				var itemID string
+				if err := runner.Run(fmt.Sprintf("Add issue %q to project %q", issue.Title, opts.ProjectName), func() error {
+					var err error
+					itemID, err = client.AddItemToProject(opts.Org, project.Number, issueURL)
+					if err != nil {
+						return err
+					}
+					return nil
+				}); err != nil {
 					return err
 				}
 				if len(issue.Fields) > 0 {
-					if err := applyIssueFields(issue.Fields, project.ID, itemID, projectFields, client); err != nil {
+					if err := applyIssueFields(issue.Fields, opts.ProjectName, issue.Title, project.ID, itemID, projectFields, client, runner); err != nil {
 						return err
 					}
 				}
@@ -159,7 +207,7 @@ func Apply(opts Options, client github.Client) error {
 		}
 	}
 
-	if sections.Project {
+	if sections.Project && !opts.DryRun {
 		fmt.Printf("Project created: %s\n", project.URL)
 	}
 	return nil
@@ -177,6 +225,23 @@ func convertFieldTemplates(fields []template.TemplateField) []github.FieldTempla
 			ft.Options = append(ft.Options, github.FieldOption{Name: opt.Name, Color: opt.Color, Description: opt.Description})
 		}
 		result = append(result, ft)
+	}
+	return result
+}
+
+func simulateProjectFieldMetadata(fields []github.FieldTemplate) map[string]github.ProjectField {
+	result := make(map[string]github.ProjectField, len(fields))
+	for idx, field := range fields {
+		options := make(map[string]github.ProjectFieldOption, len(field.Options))
+		for _, opt := range field.Options {
+			options[opt.Name] = github.ProjectFieldOption{ID: fmt.Sprintf("dry-run-field-%d-option-%s", idx, opt.Name), Name: opt.Name}
+		}
+		result[field.Name] = github.ProjectField{
+			ID:       fmt.Sprintf("dry-run-field-%d", idx),
+			Name:     field.Name,
+			DataType: field.DataType,
+			Options:  options,
+		}
 	}
 	return result
 }
@@ -216,7 +281,7 @@ func composeIssueBody(issue template.TemplateIssue) string {
 	return builder.String()
 }
 
-func applyIssueFields(fieldValues map[string]string, projectID, itemID string, projectFields map[string]github.ProjectField, client github.Client) error {
+func applyIssueFields(fieldValues map[string]string, projectName, issueTitle, projectID, itemID string, projectFields map[string]github.ProjectField, client github.Client, runner stepRunner) error {
 	if len(fieldValues) == 0 {
 		return nil
 	}
@@ -232,7 +297,10 @@ func applyIssueFields(fieldValues map[string]string, projectID, itemID string, p
 		if err != nil {
 			return fmt.Errorf("set field %s: %w", name, err)
 		}
-		if err := client.UpdateProjectItemField(projectID, itemID, meta.ID, payload); err != nil {
+		description := fmt.Sprintf("Set project field %q on issue %q in project %q", name, issueTitle, projectName)
+		if err := runner.Run(description, func() error {
+			return client.UpdateProjectItemField(projectID, itemID, meta.ID, payload)
+		}); err != nil {
 			return err
 		}
 	}

--- a/internal/apply/apply_test.go
+++ b/internal/apply/apply_test.go
@@ -1,9 +1,11 @@
 package apply
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/github/gh-templater/internal/github"
@@ -320,13 +322,13 @@ func TestApplyIssueFieldsValidation(t *testing.T) {
 	fields := map[string]github.ProjectField{
 		"Spec": {ID: "f1", Name: "Spec", DataType: "TEXT", Options: map[string]github.ProjectFieldOption{}},
 	}
-	if err := applyIssueFields(map[string]string{"unknown": "foo"}, "proj", "item", fields, client); err == nil {
+	if err := applyIssueFields(map[string]string{"unknown": "foo"}, "Demo", "Work", "proj", "item", fields, client, newStepRunner(false, nil)); err == nil {
 		t.Fatalf("expected error for missing field metadata")
 	}
-	if err := applyIssueFields(map[string]string{"Spec": "ready"}, "proj", "item", nil, client); err == nil {
+	if err := applyIssueFields(map[string]string{"Spec": "ready"}, "Demo", "Work", "proj", "item", nil, client, newStepRunner(false, nil)); err == nil {
 		t.Fatalf("expected error when no project fields available")
 	}
-	if err := applyIssueFields(map[string]string{"Spec": "ready"}, "proj", "item", fields, client); err != nil {
+	if err := applyIssueFields(map[string]string{"Spec": "ready"}, "Demo", "Work", "proj", "item", fields, client, newStepRunner(false, nil)); err != nil {
 		t.Fatalf("unexpected error applying field: %v", err)
 	}
 	if len(client.fieldUpdates) != 1 {
@@ -402,6 +404,68 @@ func TestDeleteLabels(t *testing.T) {
 	}
 	if len(client.deletedLabels) != 1 || client.deletedLabels[0] != "acme/repo:smoke-test" {
 		t.Fatalf("expected label deletion, got %+v", client.deletedLabels)
+	}
+}
+
+func TestApplyDryRunSkipsMutations(t *testing.T) {
+	tplPath := t.TempDir() + "/template.yaml"
+	content := `name: Demo
+project:
+  readme: README
+  fields:
+    - name: Status
+      data_type: TEXT
+labels:
+  - name: docs
+    color: "#abcdef"
+milestones:
+  - title: Kickoff
+issues:
+  - title: First
+    body: Ready
+    milestone: Kickoff
+    fields:
+      Status: Ready
+`
+	writeFile(tplPath, content, t)
+	client := &fakeClient{}
+	var buf bytes.Buffer
+	opts := Options{Org: "acme", ProjectName: "Demo", IssuesRepo: "acme/repo", Template: tplPath, DryRun: true, DryRunWriter: &buf}
+	if err := Apply(opts, client); err != nil {
+		t.Fatalf("apply returned error: %v", err)
+	}
+	if len(client.labels) != 0 || len(client.createdIssues) != 0 || len(client.milestones) != 0 {
+		t.Fatalf("dry run should not call client operations")
+	}
+	output := buf.String()
+	for _, expected := range []string{"Create project", "Ensure label", "Create milestone", "Create issue", "Set project field"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected dry-run output to mention %q, got %q", expected, output)
+		}
+	}
+}
+
+func TestDeleteDryRunSkipsMutations(t *testing.T) {
+	tplPath := t.TempDir() + "/template.yaml"
+	content := `labels:
+  - name: remove-me
+milestones:
+  - title: Alpha
+issues:
+  - title: Cleanup
+`
+	writeFile(tplPath, content, t)
+	client := &fakeClient{}
+	var buf bytes.Buffer
+	opts := DeleteOptions{Org: "acme", ProjectName: "Demo", IssuesRepo: "acme/repo", Template: tplPath, Sections: Sections{Project: true, Issues: true, Milestones: true, Labels: true}, DryRun: true, DryRunWriter: &buf}
+	if err := Delete(opts, client); err != nil {
+		t.Fatalf("delete returned error: %v", err)
+	}
+	if len(client.deletedLabels) != 0 || len(client.deletedIssues) != 0 || len(client.deletedMilestones) != 0 || len(client.deletedProjects) != 0 {
+		t.Fatalf("dry run should not delete resources")
+	}
+	if !strings.Contains(buf.String(), "Delete project") {
+		t.Fatalf("expected dry-run output to mention project deletion, got %q", buf.String())
 	}
 }
 

--- a/internal/apply/delete.go
+++ b/internal/apply/delete.go
@@ -3,6 +3,7 @@ package apply
 import (
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/github/gh-templater/internal/github"
@@ -11,11 +12,13 @@ import (
 
 // DeleteOptions capture inputs for removing template resources.
 type DeleteOptions struct {
-	Org         string
-	ProjectName string
-	IssuesRepo  string
-	Template    string
-	Sections    Sections
+	Org          string
+	ProjectName  string
+	IssuesRepo   string
+	Template     string
+	Sections     Sections
+	DryRun       bool
+	DryRunWriter io.Writer
 }
 
 // Delete removes template-driven resources (project, milestones, issues).
@@ -24,6 +27,7 @@ func Delete(opts DeleteOptions, client github.Client) error {
 	if !sections.anyEnabled() {
 		sections = DefaultSections()
 	}
+	runner := newStepRunner(opts.DryRun, opts.DryRunWriter)
 
 	org := strings.TrimSpace(opts.Org)
 	projectName := strings.TrimSpace(opts.ProjectName)
@@ -47,85 +51,108 @@ func Delete(opts DeleteOptions, client github.Client) error {
 	}
 
 	if sections.Issues && len(tpl.Issues) > 0 {
-		if err := deleteIssues(issuesRepo, tpl.Issues, client); err != nil {
+		if err := deleteIssues(issuesRepo, tpl.Issues, client, runner); err != nil {
 			return err
 		}
 	}
 	if sections.Milestones && len(tpl.Milestones) > 0 {
-		if err := deleteMilestones(issuesRepo, tpl.Milestones, client); err != nil {
+		if err := deleteMilestones(issuesRepo, tpl.Milestones, client, runner); err != nil {
 			return err
 		}
 	}
 	if sections.Labels && len(tpl.Labels) > 0 {
-		if err := deleteLabels(issuesRepo, tpl.Labels, client); err != nil {
+		if err := deleteLabels(issuesRepo, tpl.Labels, client, runner); err != nil {
 			return err
 		}
 	}
 	if sections.Project {
-		if err := deleteProject(org, projectName, client); err != nil {
+		if err := deleteProject(org, projectName, client, runner); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func deleteProject(org, projectName string, client github.Client) error {
+func deleteProject(org, projectName string, client github.Client, runner stepRunner) error {
 	org = strings.TrimSpace(org)
 	projectName = strings.TrimSpace(projectName)
 	if org == "" || projectName == "" {
 		return fmt.Errorf("both --org and --project are required")
 	}
-	project, err := client.FindProject(org, projectName)
-	if err != nil {
-		if errors.Is(err, github.ErrProjectNotFound) {
+	var project github.ProjectInfo
+	if err := runner.Run(fmt.Sprintf("Delete project %q under %s", projectName, org), func() error {
+		var err error
+		project, err = client.FindProject(org, projectName)
+		if err != nil {
+			if errors.Is(err, github.ErrProjectNotFound) {
+				fmt.Printf("Project %q not found under %s; skipping delete\n", projectName, org)
+				return nil
+			}
+			return err
+		}
+		if project.ID == "" {
 			fmt.Printf("Project %q not found under %s; skipping delete\n", projectName, org)
 			return nil
 		}
-		return err
-	}
-	if project.ID == "" {
-		fmt.Printf("Project %q not found under %s; skipping delete\n", projectName, org)
+		if err := client.DeleteProject(project.ID); err != nil {
+			return err
+		}
 		return nil
-	}
-	if err := client.DeleteProject(project.ID); err != nil {
+	}); err != nil {
 		return err
 	}
-	fmt.Printf("Project deleted: %s\n", project.URL)
+	if project.ID != "" && !runner.IsDryRun() {
+		fmt.Printf("Project deleted: %s\n", project.URL)
+	}
 	return nil
 }
 
-func deleteMilestones(repo string, milestones []template.TemplateMilestone, client github.Client) error {
+func deleteMilestones(repo string, milestones []template.TemplateMilestone, client github.Client, runner stepRunner) error {
 	for _, m := range milestones {
-		info, err := client.FindMilestone(repo, m.Title)
-		if err != nil {
-			if errors.Is(err, github.ErrMilestoneNotFound) {
-				continue
+		milestone := m
+		description := fmt.Sprintf("Delete milestone %q from %s", milestone.Title, repo)
+		if err := runner.Run(description, func() error {
+			info, err := client.FindMilestone(repo, milestone.Title)
+			if err != nil {
+				if errors.Is(err, github.ErrMilestoneNotFound) {
+					return nil
+				}
+				return err
 			}
-			return err
-		}
-		if err := client.DeleteMilestone(repo, info.Number); err != nil {
+			if err := client.DeleteMilestone(repo, info.Number); err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func deleteIssues(repo string, issues []template.TemplateIssue, client github.Client) error {
+func deleteIssues(repo string, issues []template.TemplateIssue, client github.Client, runner stepRunner) error {
 	for _, issue := range issues {
-		matches, err := client.FindIssues(repo, issue.Title)
-		if err != nil {
+		current := issue
+		description := fmt.Sprintf("Delete issues titled %q in %s", current.Title, repo)
+		if err := runner.Run(description, func() error {
+			matches, err := client.FindIssues(repo, current.Title)
+			if err != nil {
+				return err
+			}
+			for _, match := range matches {
+				if current.Milestone != "" && !strings.EqualFold(current.Milestone, match.Milestone) {
+					continue
+				}
+				if len(current.Labels) > 0 && !containsAll(match.Labels, current.Labels) {
+					continue
+				}
+				if err := client.DeleteIssue(match.ID); err != nil {
+					return fmt.Errorf("delete issue %q: %w", match.Title, err)
+				}
+			}
+			return nil
+		}); err != nil {
 			return err
-		}
-		for _, match := range matches {
-			if issue.Milestone != "" && !strings.EqualFold(issue.Milestone, match.Milestone) {
-				continue
-			}
-			if len(issue.Labels) > 0 && !containsAll(match.Labels, issue.Labels) {
-				continue
-			}
-			if err := client.DeleteIssue(match.ID); err != nil {
-				return fmt.Errorf("delete issue %q: %w", match.Title, err)
-			}
 		}
 	}
 	return nil
@@ -147,12 +174,16 @@ func containsAll(haystack []string, needles []string) bool {
 	return true
 }
 
-func deleteLabels(repo string, labels []template.TemplateLabel, client github.Client) error {
+func deleteLabels(repo string, labels []template.TemplateLabel, client github.Client, runner stepRunner) error {
 	for _, label := range labels {
 		if strings.TrimSpace(label.Name) == "" {
 			continue
 		}
-		if err := client.DeleteLabel(repo, label.Name); err != nil {
+		lbl := label
+		description := fmt.Sprintf("Delete label %q from %s", lbl.Name, repo)
+		if err := runner.Run(description, func() error {
+			return client.DeleteLabel(repo, lbl.Name)
+		}); err != nil {
 			return err
 		}
 	}

--- a/internal/apply/runner.go
+++ b/internal/apply/runner.go
@@ -1,0 +1,34 @@
+package apply
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+type stepRunner struct {
+	dryRun bool
+	writer io.Writer
+}
+
+func newStepRunner(dryRun bool, writer io.Writer) stepRunner {
+	if writer == nil {
+		writer = os.Stdout
+	}
+	return stepRunner{dryRun: dryRun, writer: writer}
+}
+
+func (r stepRunner) Run(description string, action func() error) error {
+	if r.dryRun {
+		if description == "" {
+			description = "(unspecified action)"
+		}
+		_, err := fmt.Fprintf(r.writer, "[dry-run] %s\n", description)
+		return err
+	}
+	return action()
+}
+
+func (r stepRunner) IsDryRun() bool {
+	return r.dryRun
+}

--- a/internal/apply/runner_test.go
+++ b/internal/apply/runner_test.go
@@ -1,0 +1,42 @@
+package apply
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+)
+
+func TestStepRunnerDryRunSkipsActionAndPrints(t *testing.T) {
+	var buf bytes.Buffer
+	runner := newStepRunner(true, &buf)
+
+	called := false
+	if err := runner.Run("example action", func() error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+	if called {
+		t.Fatalf("expected action to be skipped in dry run")
+	}
+	if got := buf.String(); got == "" || got != "[dry-run] example action\n" {
+		t.Fatalf("unexpected dry-run output: %q", got)
+	}
+}
+
+func TestStepRunnerExecutesActionWhenEnabled(t *testing.T) {
+	runner := newStepRunner(false, nil)
+
+	called := false
+	errSentinel := errors.New("boom")
+	if err := runner.Run("", func() error {
+		called = true
+		return errSentinel
+	}); !errors.Is(err, errSentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+	if !called {
+		t.Fatalf("expected action to run when not in dry run")
+	}
+}

--- a/internal/e2e/dry_run_e2e_test.go
+++ b/internal/e2e/dry_run_e2e_test.go
@@ -1,0 +1,56 @@
+package e2e_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDryRunApplyAndDeleteCli(t *testing.T) {
+	repoRoot := repoRoot(t)
+	templatePath := filepath.Join(repoRoot, testTemplate)
+
+	applyOutput := runTemplaterDryRun(t, repoRoot, "apply",
+		"--org", "acme",
+		"--project", "dry-run-preview",
+		"--issues-repo", "acme/example",
+		"--template", templatePath,
+	)
+	for _, expected := range []string{
+		"[dry-run] Create project",
+		"[dry-run] Ensure label",
+		"[dry-run] Create milestone",
+		"[dry-run] Create issue",
+	} {
+		if !strings.Contains(applyOutput, expected) {
+			t.Fatalf("apply dry run output missing %q: %s", expected, applyOutput)
+		}
+	}
+
+	deleteOutput := runTemplaterDryRun(t, repoRoot, "delete",
+		"--org", "acme",
+		"--project", "dry-run-preview",
+		"--issues-repo", "acme/example",
+		"--template", templatePath,
+	)
+	if !strings.Contains(deleteOutput, "[dry-run] Delete project") {
+		t.Fatalf("delete dry run output missing project deletion: %s", deleteOutput)
+	}
+}
+
+func runTemplaterDryRun(t *testing.T, repoRoot, subcommand string, args ...string) string {
+	t.Helper()
+	cmdArgs := append([]string{"run", "./cmd/gh-templater", subcommand}, args...)
+	cmdArgs = append(cmdArgs, "--dry-run")
+
+	cmd := exec.Command("go", cmdArgs...)
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(), "GH_TOKEN=", "GITHUB_TOKEN=")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gh-templater %s dry run failed: %v: %s", subcommand, err, string(output))
+	}
+	return string(output)
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -701,7 +701,11 @@ func (c *CLIClient) runGraphQL(query string, variables map[string]interface{}) (
 	if err != nil {
 		return "", err
 	}
-	defer os.Remove(file.Name())
+	defer func() {
+		if removeErr := os.Remove(file.Name()); removeErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to cleanup graphql payload %s: %v\n", file.Name(), removeErr)
+		}
+	}()
 	if _, err := file.Write(data); err != nil {
 		if cerr := file.Close(); cerr != nil {
 			return "", fmt.Errorf("write graphql payload: %v (close error: %w)", err, cerr)


### PR DESCRIPTION
## Summary
- add a dry-run mode to the apply and delete commands with a shared step runner so actions can be previewed without calling the GitHub API
- update the CLI, README, and helper logic to surface the new flag and to provide richer output when running in preview mode
- expand the unit tests to cover the dry-run planner, add regression coverage for field application, and clean up deferred file handling in the GitHub client

## Testing
- `make all`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691da9d8743483229bef73b0f3ecd45e)